### PR TITLE
Add MaxVelocity property and clamping method (Fixes #122)

### DIFF
--- a/EvoSim/ECS/Components/VelocityComponent.cs
+++ b/EvoSim/ECS/Components/VelocityComponent.cs
@@ -21,6 +21,11 @@ public class VelocityComponent : IComponent
     /// </summary>
     public float VY { get; set; }
 
+        /// <summary>
+            /// Gets or sets the maximum velocity magnitude that this object can achieve.
+                /// </summary>
+                    public float MaxVelocity { get; set; }
+
     /// <summary>
     /// Gets the squared magnitude of the total velocity, calculated as the sum of the squares of the X and Y velocity
     /// components.
@@ -40,5 +45,6 @@ public class VelocityComponent : IComponent
     /// </summary>
     public bool HasVelocity => VX != 0 || VY != 0; // TODO: consider a small epsilon for floating-point precision
 }
+
 
 

--- a/EvoSim/ECS/Utilities/VelocityUtility.cs
+++ b/EvoSim/ECS/Utilities/VelocityUtility.cs
@@ -23,9 +23,27 @@ public static class VelocityUtility
     {
         if (!velocityComponent.HasVelocity) return; // No movement if velocity is zero
 
-        // TODO: add max velocity limit based on entity traits
+        ClampVelocityToMax(velocityComponent);
 
         positionComponent.X += (int)(velocityComponent.VX * deltaTime);
         positionComponent.Y += (int)(velocityComponent.VY * deltaTime);
     }
+
+        /// <summary>
+        /// Clamps the velocity to the maximum allowed value if MaxVelocity is set.
+        /// </summary>
+        /// <param name="velocityComponent">The velocity component to clamp.</param>
+        public static void ClampVelocityToMax(VelocityComponent velocityComponent)
+                {
+                    if (velocityComponent.MaxVelocity <= 0) return; // No clamping if MaxVelocity is not set
+
+                    float currentSpeed = velocityComponent.TotalVelocity;
+                    if (currentSpeed > velocityComponent.MaxVelocity)
+                                {
+                                    float scale = velocityComponent.MaxVelocity / currentSpeed;
+                                    velocityComponent.VX *= scale;
+                                    velocityComponent.VY *= scale;
+                                }
+                }
+
 }


### PR DESCRIPTION
## Description
This PR implements the MaxVelocity feature requested in issue #122.

## Changes Made
1. Added `MaxVelocity` property to `VelocityComponent` class
2. Created `ClampVelocityToMax()` method in `VelocityUtility` class
3. Updated `ApplyVelocityToPosition()` to call the clamping method

## How It Works
- The `MaxVelocity` property allows setting a maximum velocity magnitude for entities
- When velocity exceeds the max, it's scaled down proportionally while maintaining direction
- If `MaxVelocity` is 0 or not set, no clamping is applied

## Related Issue
Fixes #122